### PR TITLE
refactor: Use Result alias, over raw std::Result.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,11 @@ use {
     bitvec::{BitVec, Bits},
     byteorder::ByteOrder,
     digest::Digest,
-    failure::Error,
     num_integer::div_rem,
     std::marker::PhantomData,
 };
+
+type Result<T> = std::result::Result<T, failure::Error>;
 
 #[derive(Debug, Fail)]
 enum GcsError {
@@ -72,7 +73,7 @@ impl<D: Digest> GcsBuilder<D> {
     }
 
     /// Adds an entry to the set, and returns an error if more than N items are added
-    pub fn insert(&mut self, input: &[u8]) -> Result<(), Error> {
+    pub fn insert(&mut self, input: &[u8]) -> Result<()> {
         if (self.values.len() as u64) < self.n {
             self.values.push(digest_value::<D>(self.n, self.p, input));
             Ok(())


### PR DESCRIPTION
This will be more useful as more methods that require `Result` such as metntioned in #1 are added.